### PR TITLE
Update config for asl to adhere to bids standard

### DIFF
--- a/asl_swi_config.json
+++ b/asl_swi_config.json
@@ -2,20 +2,21 @@
     "descriptions": [
         {
             "datatype": "perf",
-            "suffix": "ASL",
-            "custom_entities": "acq-CASL",
+            "suffix": "m0scan",
             "criteria": {
                 "SeriesDescription": "ASL",
-                "ArterialSpinLabelingType": "CASL"
+                "ImageType": ["ORIGINAL", "PRIMARY", "ASL"]
             }
         },
         {
             "datatype": "perf",
-            "suffix": "ASL",
-            "custom_entities": "acq-PCASL",
+            "suffix": "asl",
             "criteria": {
                 "SeriesDescription": "ASL",
-                "ArterialSpinLabelingType": "PCASL"
+                "ImageType": ["DERIVED", "PRIMARY", "ASL", "PERFUSION", "ASL"]
+            },
+            "sidecar_changes": {
+                "M0Type": "Seperate"
             }
         },
         {


### PR DESCRIPTION
This PR updates the config file for the ASL data. From the GE scanner, we get one DICOM, which gets split into two ASL images after running dcm2niix. Those two images are:

_m0scan_: The M0 image is a calibration image, used to estimate the equilibrium magnetization of blood.
_deltam_: The deltaM image is a perfusion-weighted image, obtained by the subtraction of control - label.

The _m0scan_ is an original file, and _deltam_ is derived. Following the [BIDS standard ](https://bids-specification.readthedocs.io/en/stable/modality-specific-files/magnetic-resonance-imaging-data.html#arterial-spin-labeling-perfusion-data), the deltam image will get the suffix `asl`, and the m0scan the suffix `m0scan `If the m0scan and deltam are not combined as one 4D image, we need to update the sidecar with `"M0Type": "Seperate"`

Of note: The BIDS standard seems to prefer having both _deltam_ and _m0scan_ in one 4D image with the suffix `asl`.  Then you would need to add an extra `_aslcontext.tsv` indicating the order of the volume. I have not figured out yet how to do that the best way, as the sidecars are slightly different. However, it should still be compliment as is.